### PR TITLE
dependabot: ignore patternfly 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
         patterns:
           - '@redhat-cloud-services/*'
     ignore:
+      - dependency-name: '@patternfly/*'
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: 'eslint'
         update-types:
           - 'version-update:semver-major'


### PR DESCRIPTION
PF6 came out, crc doesn't support it yet,
stopping dependabot from offering that update.

(Closes #156)