### PR TITLE
HubCard - switch hub Partners/Collections/sync counts to css grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10156,10 +10156,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/src/components/automation-hub/hub-card.js
+++ b/src/components/automation-hub/hub-card.js
@@ -103,86 +103,70 @@ const HubCard = () => {
           <br />
         </Text>
       </TextContent>
-      <Flex>
-        <Flex
-          direction={{ default: 'column' }}
-          className="pf-v5-u-m-0 pf-v5-u-pr-sm"
-        >
-          <FlexItem
-            align={{ default: 'alignRight' }}
-            className="pf-v5-u-mb-sm pf-v5-u-mt-md"
+      <Grid hasGutter>
+        <GridItem align="right" span={2}>
+          <TextContent>
+            <Text component={TextVariants.h1}>{partners?.meta?.count}</Text>
+          </TextContent>
+        </GridItem>
+        <GridItem span={10}>
+          <Button
+            component="a"
+            variant="link"
+            href={`${release}ansible/automation-hub/partners`}
           >
-            <TextContent>
-              <Text component={TextVariants.h1}>{partners?.meta?.count}</Text>
-            </TextContent>
-          </FlexItem>
-          <FlexItem
-            align={{ default: 'alignRight' }}
-            className="pf-v5-u-mb-sm pf-v5-u-mt-md"
+            {intl.formatMessage(messages.partners)}
+          </Button>
+        </GridItem>
+
+        <GridItem align="right" span={2}>
+          <TextContent>
+            <Text component={TextVariants.h1}>{collections?.meta?.count}</Text>
+          </TextContent>
+        </GridItem>
+        <GridItem span={10}>
+          <Button
+            component="a"
+            variant="link"
+            href={`${release}ansible/automation-hub`}
           >
-            <TextContent>
-              <Text component={TextVariants.h1}>
-                {collections?.meta?.count}
-              </Text>
-            </TextContent>
-          </FlexItem>
-          <FlexItem
-            align={{ default: 'alignRight' }}
-            className="pf-v5-u-mb-sm pf-v5-u-mt-md"
-          >
-            <TextContent>
-              <Text component={TextVariants.h1}>
-                {syncCollections?.meta?.count}
-              </Text>
-            </TextContent>
-          </FlexItem>
-        </Flex>
-        <Flex direction={{ default: 'column' }}>
-          <FlexItem>
-            <Button
-              component="a"
-              variant="link"
-              href={`${release}ansible/automation-hub/partners`}
-            >
-              {intl.formatMessage(messages.partners)}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <Button
-              component="a"
-              variant="link"
-              href={`${release}ansible/automation-hub`}
-            >
-              {intl.formatMessage(messages.collections)}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <Level hasGutter className="pf-v5-u-pl-md pf-v5-u-pt-sm">
-              <LevelItem style={{ marginRight: 8 }}>
-                {intl.formatMessage(messages.syncCollections)}
-              </LevelItem>
-              <LevelItem>
-                <Popover
-                  headerContent={
-                    <div>{intl.formatMessage(messages.syncCollections)}</div>
-                  }
-                  bodyContent={
-                    <div>
-                      {intl.formatMessage(messages.syncCollectionsTooltip)}
-                    </div>
-                  }
-                >
-                  <Button
-                    variant="link"
-                    style={{ padding: 0 }}
-                    icon={<OutlinedQuestionCircleIcon />}
-                  />
-                </Popover>
-              </LevelItem>
-            </Level>
-          </FlexItem>
-        </Flex>
-      </Flex>
+            {intl.formatMessage(messages.collections)}
+          </Button>
+        </GridItem>
+
+        <GridItem align="right" span={2}>
+          <TextContent>
+            <Text component={TextVariants.h1}>
+              {syncCollections?.meta?.count}
+            </Text>
+          </TextContent>
+        </GridItem>
+        <GridItem span={10}>
+          <Level hasGutter className="pf-v5-u-pl-md pf-v5-u-pt-sm">
+            <LevelItem style={{ marginRight: 8 }}>
+              {intl.formatMessage(messages.syncCollections)}
+            </LevelItem>
+            <LevelItem>
+              <Popover
+                headerContent={
+                  <div>{intl.formatMessage(messages.syncCollections)}</div>
+                }
+                bodyContent={
+                  <div>
+                    {intl.formatMessage(messages.syncCollectionsTooltip)}
+                  </div>
+                }
+              >
+                <Button
+                  variant="link"
+                  style={{ padding: 0 }}
+                  icon={<OutlinedQuestionCircleIcon />}
+                />
+              </Popover>
+            </LevelItem>
+          </Level>
+        </GridItem>
+      </Grid>
     </>
   );
 


### PR DESCRIPTION
the flexbox layout would put all the numbers first, and then all the labels, if the viewport was too narrow switch to a grid layout which puts the numbers and labels side by side when possible

Issue: AAP-32416

Before:
![20241104135030](https://github.com/user-attachments/assets/c8cf61ba-2631-4567-98fe-bd028a977ea6)

After:
![20241104135952](https://github.com/user-attachments/assets/0ab534da-3e45-4257-a502-aef7817cbfdb)

